### PR TITLE
Add support for deployed dev env + cookie domain

### DIFF
--- a/cmd/server/configs/dev.conf
+++ b/cmd/server/configs/dev.conf
@@ -1,5 +1,5 @@
 env dev
-allowed_cors_origins https://*.dev.rmi.siliconally.org
+allowed_cors_origins https://*.dev.rmi.siliconally.dev
 sops_path /configs/secrets/dev.enc.json
 
 port 80
@@ -8,3 +8,4 @@ use_local_jwts false
 enable_credential_test_api true
 
 allowed_domains siliconally.org,rmi.org
+cookie_domain dev.rmi.siliconally.dev

--- a/cmd/server/configs/secrets/dev.enc.json
+++ b/cmd/server/configs/secrets/dev.enc.json
@@ -6,7 +6,7 @@
 	"azure_ad": {
 		"tenant_name": "ENC[AES256_GCM,data:+lYDsjbq3k9aCw==,iv:y8Qs1UEujN+AQbnkuiviCCyPL+2szBDVsHtAtgEZu3k=,tag:SGPruSzn+oydEzBKliKCMw==,type:str]",
 		"user_flow": "ENC[AES256_GCM,data:etuKpWOl81pb9JCeqQM=,iv:HcAlJrAAr7STvZxeJUg36BDtmRbaU8D314A8MqkiFTs=,tag:DZs4sDRWmtM87YYOYm1fPA==,type:str]",
-		"client_id": "ENC[AES256_GCM,data:2pUNlsnnAaBx2n3sIJbQBPiSzAS5HNG4KQrLgpp4EBio51m+,iv:RbZESb/quCoa8rB3gP1m/+EjEVbwPnY9DdNbW9NMquI=,tag:LrTascNYVPcXWADNDsjZbw==,type:str]",
+		"client_id": "ENC[AES256_GCM,data:9N/Wo54QYtRdLkM8WewGa30+EW9OChk1pAtqla6rUs257xa0,iv:jbz4oPzHabgnoymCC+Vytpe+6+rLrS5Xbaz/Kisbaf0=,tag:R63pPKQi24WoB/blaX3ssw==,type:str]",
 		"tenant_id": "ENC[AES256_GCM,data:g43bRL2/BOJ89R0z62O5FwP4XCP0nVt10brZOKBrcw03K05y,iv:dTY6yep98gdOO1QQYKuTruzGJquSZSU79w7cZuo3PKg=,tag:dtNJcr8yyeU1RXU51n+Z6Q==,type:str]"
 	},
 	"sops": {
@@ -23,8 +23,8 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-09-20T18:24:31Z",
-		"mac": "ENC[AES256_GCM,data:w9o3mjj60/laZtvsEhPTVy753RU+8wtgf0fx9QLNWSJHB+jYy/XlfKWV9Stdt9oj/ZPFzV1Iawck6mbfEBel2+C7f6b7v/iOUj2enasYbx0W6ePly8V0qP9E9ADWt7TrXC5C2Q/gQoxtxAi73EVNI1MloW9c8+IlxJKiXF5/+Vk=,iv:azK9/81MAj7jte2yEuW3NYGm07mefOXiybnlsGZAbfA=,tag:DinlQIzkpmXAXzln80/h5Q==,type:str]",
+		"lastmodified": "2023-09-27T16:43:22Z",
+		"mac": "ENC[AES256_GCM,data:uke1E1vznL21zbgaJOy0xm8SICTeMAa29jrxzPO05GUdNuTF33toUR/jKLZaEFQfTIhFGLZmFQyxvlZeMgW6nH/tO8n4pXWdcOHbABJ4Pw2yvmtnPAKtWanOc3/gnOnZMDKyPwrodCRmA69SWPFI+hRzRt/P4JxEsRMaELhtzU4=,iv:zQGOyBuG5d+CnsYfAlj8oiReKmlgl9bi6VRYYH1nU/w=,tag:757RH3ObWchQL9ofCRgEOQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.3"

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -77,6 +77,8 @@ func run(args []string) error {
 
 		enableCredTest = fs.Bool("enable_credential_test_api", false, "If true, enables the credential testing API, which returns if credentials are valid")
 
+		cookieDomain = fs.String("cookie_domain", "", "Domain to return in the cookie response")
+
 		allowedDomains     flagext.StringList
 		allowedCORSOrigins flagext.StringList
 		minLogLevel        zapcore.Level = zapcore.WarnLevel
@@ -161,8 +163,9 @@ func run(args []string) error {
 			Key: jwKey,
 			Now: time.Now,
 		},
-		Logger: logger,
-		Now:    func() time.Time { return time.Now().UTC() },
+		Logger:       logger,
+		Now:          func() time.Time { return time.Now().UTC() },
+		CookieDomain: *cookieDomain,
 	}
 	testCredsSrv := &testcredsrv.Server{
 		Now:     func() time.Time { return time.Now().UTC() },

--- a/cmd/server/usersrv/usersrv.go
+++ b/cmd/server/usersrv/usersrv.go
@@ -51,9 +51,10 @@ func (t *TokenIssuer) IssueToken(userID string, emails []string, exp time.Time) 
 }
 
 type Server struct {
-	Issuer *TokenIssuer
-	Logger *zap.Logger
-	Now    func() time.Time
+	Issuer       *TokenIssuer
+	Logger       *zap.Logger
+	Now          func() time.Time
+	CookieDomain string
 }
 
 // Exchange a user JWT token for an API key that can be used with other RMI APIs
@@ -131,6 +132,7 @@ func (s *Server) Login(ctx context.Context, req user.LoginRequestObject) (user.L
 		Secure:   true,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
+		Domain:   s.CookieDomain,
 	}
 
 	return user.Login200Response{
@@ -151,6 +153,7 @@ func (s *Server) Logout(ctx context.Context, req user.LogoutRequestObject) (user
 		Secure:   true,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
+		Domain:   s.CookieDomain,
 	}
 
 	return user.Logout200Response{


### PR DESCRIPTION
Cookie domain is needed so that cookies 'stick' when set on site-one.example.com vs site-two.example.com
