### PR TITLE
Add encrypted allowlists back to the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /test_server.pub
 
 /cmd/server/configs/allowlists/*.json
+!/cmd/server/configs/allowlists/*.enc.json
 !/cmd/server/configs/allowlists/example.json

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,7 @@
+# creation rules are evaluated sequentially, the first match wins
+creation_rules:
+        - path_regex: cmd/server/configs/allowlists/local\.enc\.json$
+          azure_keyvault: https://rmicredsrvlocalsops.vault.azure.net/keys/sops/8c544f0ae62b4d5a9b1c7ef755345f22
+        - path_regex: cmd/server/configs/allowlists/dev\.enc\.json$
+          azure_keyvault: https://rmicredsrvdevsops.vault.azure.net/keys/sops/2e4989d46cb24ccb96c8ce98e9104fe5
+

--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ The service currently has two main credential-exchanging endpoints:
 Things to note:
 
 - Only Azure AD B2C is supported as a source of exchangable user ID tokens at the moment, see [the server `main.go`](/cmd/server/main.go) and the [`azjwt` package](/azure/azjwt/azjwt.go) for more details.
-- The allowlists themselves (i.e. in `cmd/server/configs/allowlists/{local,dev}.json`, are **not** included in this repo. If you're deploying the actual RMI service, get these from one of the developers.
 
 ## Running the Credential Service
 
-Before running the service locally, you'll need an allowlist at `cmd/server/configs/allowlists/local.json`. You can create one based on the `example.json` in the same directory.
+Before running the service locally, make sure you have [`sops`](https://github.com/getsops/sops) installed, and are logged into Azure with credentials that can access the relevant keys. See the `.sops.yaml` for more info.
 
 Run the server against an Azure AD B2C instance:
 

--- a/cmd/server/configs/allowlists/dev.enc.json
+++ b/cmd/server/configs/allowlists/dev.enc.json
@@ -1,0 +1,43 @@
+{
+	"format": "ENC[AES256_GCM,data:0ng=,iv:K4sJe4k2+fpSL4xFf3vfmWg4x9m8N8SJZ2xIbPsZac0=,tag:88YJM6L3VZm8UD6AO8/8Ew==,type:str]",
+	"allowlist": [
+		{
+			"domain": "ENC[AES256_GCM,data:15CUX46jvNt4sk47qxrZ,iv:nakMtPsaOowiv9xjzdjDHBSTru23GOOWb7iHS1Bneyg=,tag:vkY7N7I0aAhIe42pGHNSuQ==,type:str]"
+		},
+		{
+			"domain": "ENC[AES256_GCM,data:x1dbzZJNJg==,iv:XkBy+eQJa4Zfh4eeAk5FG6+oqZdayUx9gENHe8WNQxA=,tag:J11pswlCyxJOz7gNE2n0kA==,type:str]"
+		},
+		{
+			"domain": "ENC[AES256_GCM,data:YuK4iar/QnmEMw==,iv:GVNcCRSgEoSFdGMbHVYRWyhIwh7AGbSKboiugEoknNg=,tag:8LiqP0Fo6SIF3eLgMpkwRQ==,type:str]",
+			"sites": [
+				"ENC[AES256_GCM,data:myKSo3g=,iv:MJDynUIk9BV3kbYoobPUBCnkkGr2PKaW3VJHvaoNeqI=,tag:NSfv4n1WDsh0B3pC2yvM+g==,type:str]"
+			]
+		},
+		{
+			"email": "ENC[AES256_GCM,data:jFfwttirzkF6h9Hg+jHP5gyptcM611m1kw8=,iv:TnxBfLhNHe66JsmdMYCzjC8IY2FIFQfP4uazHZe3/SE=,tag:0Lil6K5yiZlnIK7+aYjlqw==,type:str]",
+			"sites": [
+				"ENC[AES256_GCM,data:DiqPF94=,iv:5Kqz5mMgjnBEBM/3cfHOS0/v5Tw0OC342ZwTg5EPYr0=,tag:cKbvZ6DLKOB69NzUYzR7uw==,type:str]"
+			]
+		}
+	],
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": [
+			{
+				"vault_url": "https://rmicredsrvdevsops.vault.azure.net",
+				"name": "sops",
+				"version": "2e4989d46cb24ccb96c8ce98e9104fe5",
+				"created_at": "2024-07-09T23:37:25Z",
+				"enc": "ZYDGWfLJWxYjiwJPbcoo8TKn96iW5FrBGHJpkh0_YQcNqNZdT6hKNOajIKSnTTFD5wTsZGUKkNInRb2ps90p17j-mfuzt_lnHxPzFoQUcDNKZr3PDH1oMy-9jGTE5xIb9QK5We7B0J5xtCb4R4sRa5K6A6-l8GBvrAV2GDFtZTV5QUyJD6xk0D7QRd3AsUriIQmdCsE3pNvyAfuICuGDF3Hcc-7JOZSQWWvo7C5F7JvnILXlftOTpgf3j8oh-QgxkiCZ4shcIEuoEl7PoSsZoCYIzoVWo5H4jw-i1nnEFULkSzZu91K4cFrIXmMCoRqO8ncR09GYhl973ydV1SsnNA"
+			}
+		],
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2024-07-09T23:37:27Z",
+		"mac": "ENC[AES256_GCM,data:x5Qc4sfLdsKL0dv1FV0SN+rEckwHS7HkSgFTSP+mwEAT1YsYGG4L834kyjjS4ibHfQUuJ2UtEVL33qaTTMTr1HYiaLOwJ9gI9yuJ5S5HY6lJl5uq56DyhUKUsbMKycSBErdSPB5vmXjUJK49WVRsP6F6l+aFiK9XBlcmVOqihLA=,iv:37uK9ABwjg14IcQGC3yirSzfySDM5nNbH/Fz8Rs1c2A=,tag:hDxVX3y/y9zyaYdFpQtSlA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.8.1"
+	}
+}

--- a/cmd/server/configs/allowlists/local.enc.json
+++ b/cmd/server/configs/allowlists/local.enc.json
@@ -1,0 +1,37 @@
+{
+	"format": "ENC[AES256_GCM,data:8As=,iv:7qOQHvaWw7X7vVoda3mD+T1+EgceABeEqKyLyQ7dPZY=,tag:JxYpiTUjFRvkLTo3Jv3nAQ==,type:str]",
+	"allowlist": [
+		{
+			"domain": "ENC[AES256_GCM,data:gyLWCyQCpA39X5lNnhJA,iv:3uDN8IK1KCebmQoSqBtZJ/C2ISx6/oFA6z4VwCKjq4s=,tag:UkK/fHPkOo2XURuFylL21w==,type:str]"
+		},
+		{
+			"domain": "ENC[AES256_GCM,data:CgTDWaRi8g==,iv:m3CxDdiPvUgipbt99slSo0X3SBPk3j85gYiYs+DYS+I=,tag:DgAC6WB0Xy2BTH4fMoT8Bg==,type:str]"
+		},
+		{
+			"domain": "ENC[AES256_GCM,data:ntaKa04sDnpL2g==,iv:+i13RpV3HhMi72uQtH3q4zKBVpwgXwlVVvKiPWZnl/c=,tag:C4useGjIUS8Raf4H9n68GQ==,type:str]",
+			"sites": [
+				"ENC[AES256_GCM,data:3Gn/Cl0=,iv:0Skki3NGNg97sxMpdJUhP/N33DosGfIb5EiUu2jqwow=,tag:3V0WhDJo5MyqukP7yAPS1g==,type:str]"
+			]
+		}
+	],
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": [
+			{
+				"vault_url": "https://rmicredsrvlocalsops.vault.azure.net",
+				"name": "sops",
+				"version": "8c544f0ae62b4d5a9b1c7ef755345f22",
+				"created_at": "2024-07-09T23:36:00Z",
+				"enc": "d5iHI1RFchiNyvaSNwV7NPeT8-CEFMErX2lRsDdWwoesMInRLzxQ0QU9Y7YH3YtzT-KG5ZE6QyoU2wEOyUr4OOd_rypMCZFYByHuh7Se_yvfXsRju_Swwy2Qe7dYa2pZhFRFaHMOkxv_Zj9qsTP7_UZhhOEIOdHFS7u_1sEmUgcdhycYSt1BomvrRqm-4xG506Hl08lCWJkR8JbvIjkAM3HXICtSwkjyRy3oBCJ5wLw_loCJoZaAaLIV2SEOFD7tw-Hsi_Ocu9J1VcLheXzaJuH0mmLGMkZpYkUR6OovDm59mgCoBaYLxsjIeC2cCmt5IWe6qQ9i05Brnbdqzs2n0g"
+			}
+		],
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2024-07-09T23:36:02Z",
+		"mac": "ENC[AES256_GCM,data:7c+OuHsG6EWmlzq0ybfKcTNxOnTZI1OVvjWvu5laIYUBDcqrZKAF0qvLnyJZ7ms8eUjP1f4kVmd52IEcBg8Hpldwi7oDQks9KyC75zYWFoVOTSnoneyCbyYBz0F3OnaSHum7cxbpHDNFc1IJlPggfyufcG1uW9rfLr6f2lDxvpc=,iv:+i7V/r3+A5l2hwqlsAzj/eHCV8DdaYD9EPqLauXZI18=,tag:kB6b0b0AdwbtTGdxoRYqlQ==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.8.1"
+	}
+}

--- a/cmd/server/configs/local.conf
+++ b/cmd/server/configs/local.conf
@@ -1,6 +1,6 @@
 env local
 allowed_cors_origins http://localhost:3000
-allowlist_file cmd/server/configs/local.json
+# allowlist_file is added by our /scripts/run_server.sh script
 
 use_local_jwts true
 enable_credential_test_api true

--- a/scripts/run_server.sh
+++ b/scripts/run_server.sh
@@ -23,10 +23,26 @@ OPTS=$(getopt \
   -- "$@"
 )
 
+if ! [ -x "$(command -v sops)" ]; then
+  echo 'Error: sops is not installed.' >&2
+  exit 1
+fi
+
+TMP_CONFIG_DIR="$(mktemp -d -t credsrv-local-XXXXXXXXX)"
+function cleanup {
+  rm -rf "$TMP_CONFIG_DIR"
+}
+trap cleanup EXIT
+TMP_ALLOWLIST_FILE="${TMP_CONFIG_DIR}/local.json"
+TMP_CONFIG_FILE="${TMP_CONFIG_DIR}/local.conf"
+sops -d "$ROOT/cmd/server/configs/allowlists/local.enc.json" > "$TMP_ALLOWLIST_FILE"
+cp "$ROOT/cmd/server/configs/local.conf" "$TMP_CONFIG_FILE"
+printf "\nallowlist_file %s\n" "$TMP_ALLOWLIST_FILE" >> "$TMP_CONFIG_FILE"
+
 eval set --$OPTS
 
 declare -a FLAGS=(
-  "--config=cmd/server/configs/local.conf"
+  "--config=$TMP_CONFIG_FILE"
 )
 while [ ! $# -eq 0 ]
 do


### PR DESCRIPTION
This PR adds back the allowlists, now encrypted with `sops`.

The `run_server.sh` script has been updated to automatically decrypt relevant files ahead of time.

...I realized after that we probably don't need to encrypt `local.json`, but hey, it's done now.
